### PR TITLE
Add Flutter phone call example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,14 @@
-# example-app
+# Example Phone App
+
+This repository contains a minimal Flutter application that demonstrates how to launch a phone call on iOS.
+
+The Flutter project is located in `phone_app/`. You can open it with Flutter and run it on an iOS device or simulator.
+
+## Getting Started
+
+1. Ensure Flutter is installed.
+2. Navigate to the `phone_app` directory.
+3. Run `flutter pub get` to install dependencies.
+4. Launch the app with `flutter run`.
+
+The main screen allows entering a phone number and tapping **Call** to open the dialer.

--- a/phone_app/ios/Runner/Info.plist
+++ b/phone_app/ios/Runner/Info.plist
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>CFBundleIdentifier</key>
+  <string>com.example.phoneapp</string>
+  <key>CFBundleName</key>
+  <string>phone_app</string>
+  <key>LSApplicationQueriesSchemes</key>
+  <array>
+    <string>tel</string>
+  </array>
+</dict>
+</plist>

--- a/phone_app/lib/main.dart
+++ b/phone_app/lib/main.dart
@@ -1,0 +1,63 @@
+import 'package:flutter/material.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+void main() => runApp(const PhoneApp());
+
+class PhoneApp extends StatelessWidget {
+  const PhoneApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: 'Phone App',
+      home: const DialPage(),
+    );
+  }
+}
+
+class DialPage extends StatefulWidget {
+  const DialPage({super.key});
+
+  @override
+  State<DialPage> createState() => _DialPageState();
+}
+
+class _DialPageState extends State<DialPage> {
+  final TextEditingController _controller = TextEditingController();
+
+  Future<void> _call() async {
+    final phone = _controller.text;
+    final uri = Uri(scheme: 'tel', path: phone);
+    if (await canLaunchUrl(uri)) {
+      await launchUrl(uri);
+    } else {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Dialer not available')),
+      );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Call')),
+      body: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          children: [
+            TextField(
+              controller: _controller,
+              keyboardType: TextInputType.phone,
+              decoration: const InputDecoration(labelText: 'Phone number'),
+            ),
+            const SizedBox(height: 16),
+            ElevatedButton(
+              onPressed: _call,
+              child: const Text('Call'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/phone_app/pubspec.yaml
+++ b/phone_app/pubspec.yaml
@@ -1,0 +1,19 @@
+name: phone_app
+description: A simple phone dialer app.
+publish_to: 'none'
+version: 0.0.1
+
+environment:
+  sdk: '>=2.17.0 <3.0.0'
+
+dependencies:
+  flutter:
+    sdk: flutter
+  url_launcher: ^6.1.5
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+
+flutter:
+  uses-material-design: true


### PR DESCRIPTION
## Summary
- add a Flutter example app to dial phone numbers on iOS
- document how to run the example

## Testing
- `git status --short`